### PR TITLE
submoduleの表記を小文字mainroadに変更

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "themes/Mainroad"]
-	path = themes/Mainroad
+[submodule "themes/mainroad"]
+	path = themes/mainroad
 	url = https://github.com/Vimux/Mainroad.git


### PR DESCRIPTION
- submoduleの設定ファイルを変更した関係でビルドが通らなくなったと思われるので修正
- https://github.com/nitmic-git/nitmic-hp/pull/89/commits/79ea3f065d9bee945b6a796951f0c4cec9221ba3
- https://github.com/nitmic-git/nitmic-hp/blob/develop/.github/workflows/hugo.yml
- https://github.com/nitmic-git/nitmic-hp/actions/runs/8527953597/job/23360504809