### PR TITLE
zennのリンクを追加

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -65,3 +65,8 @@ summaryLength = 130
   title = "SoundCloud"
   icon = "soundcloud_icon.svg"
   url = "https://soundcloud.com/mic-nit"
+
+[[Params.widgets.social.custom]]
+  title = "Zenn"
+  icon = "logo-only-white.svg"
+  url = "https://zenn.dev/p/nitmic"

--- a/layouts/partials/logo-only-white.svg
+++ b/layouts/partials/logo-only-white.svg
@@ -1,0 +1,16 @@
+<svg 
+	class="{{ with .class }}{{ . }} {{ end }} icon icon-zenn" 
+	version="1.1" 
+	xmlns="http://www.w3.org/2000/svg" 
+	xmlns:xlink="http://www.w3.org/1999/xlink" 
+    width="24" height="24" 
+    viewBox="0 0 100 100"
+    enable-background="new 0 0 512 512" 
+>
+<g fill="#FFF">
+	<path class="st0" d="M3.9,83.3h17c0.9,0,1.7-0.5,2.2-1.2L69.9,5.2c0.6-1-0.1-2.2-1.3-2.2H52.5c-0.8,0-1.5,0.4-1.9,1.1L3.1,81.9
+		C2.8,82.5,3.2,83.3,3.9,83.3z"/>
+	<path class="st0" d="M62.5,82.1l22.1-35.5c0.7-1.1-0.1-2.5-1.4-2.5h-16c-0.6,0-1.2,0.3-1.5,0.8L43,81.2c-0.6,0.9,0.1,2.1,1.2,2.1
+		h16.3C61.3,83.3,62.1,82.9,62.5,82.1z"/>
+</g>
+</svg>


### PR DESCRIPTION
## 行ったこと
- [zennのアイコンsvg](https://zenn.dev/mediakit)をダウンロードしてきて追加
- CSSが適応されるようにsvgを微調整
- config.tomlにzennのwidgetを追加するように記述

## 写真
![image](https://github.com/nitmic-git/nitmic-website/assets/69578376/85793ee7-9002-4f3f-bfa8-c06b5cd18cd2)
