### PR TITLE
fix: 開発コンテナでビルドが失敗するため Features のバージョンを固定

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,6 +23,8 @@
 		}
 	},
 	"features": {
-		"ghcr.io/devcontainers/features/hugo:1": {}
+		"ghcr.io/devcontainers/features/hugo:1": {
+			"version": "0.115.4"
+		}
 	}
 }


### PR DESCRIPTION
# Why

- 開発コンテナにおいてビルドに失敗するから

# What

- Features の HUGO のバージョンを固定した
  - とりあえずビルドワークフローと同じバージョンを指定した