### PR TITLE
Update hugo.yml

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -60,7 +60,7 @@ jobs:
             --gc \
             --minify    
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: public
           path: public/
@@ -71,7 +71,7 @@ jobs:
     needs: build
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: public
       - name: Copy build artifacts


### PR DESCRIPTION
actions/upload-artifact と actions/download-artifact のバージョンを更新する．
基本的にこれらのバージョンが異なっていても問題は起きない．
したがって，GitHub Hosted Runner で実行する actions/upload-artifact は最新のバージョンにした．
一方で，actions/download-artifact を実行する Self Hosted Runner は Node 18 までしかインストールされていないため，ひとまず v3 を試すのがよいと思われる．