### PR TITLE
feat: Add disk space alert workflow

### DIFF
--- a/.github/workflows/disk_space_alert.yml
+++ b/.github/workflows/disk_space_alert.yml
@@ -1,0 +1,37 @@
+name: Disk Space Alert
+
+on:
+  schedule:
+    - cron: '0 18 * * 1'
+  workflow_run:
+    workflows:
+      - Build Hugo site and upload to release
+    types:
+      - completed
+
+jobs:
+  check-disk:
+    runs-on: self-hosted
+    steps:
+      - name: Check Disk Usage
+        id: check_disk
+        run: |
+          DISK_USAGE=$(du -sh --block-size=1G ~ | awk '{print $1}')
+          TOTAL_DISK=4
+
+          echo "DISK_USAGE=${DISK_USAGE}" >> $GITHUB_OUTPUT
+          echo "TOTAL_DISK=${TOTAL_DISK}" >> $GITHUB_OUTPUT
+
+          echo "### ディスク使用状況" >> $GITHUB_STEP_SUMMARY
+          echo "${DISK_USAGE}GB / ${TOTAL_DISK}GB" >> $GITHUB_STEP_SUMMARY
+
+      - name: Check Threshold
+        run: |
+          THRESHOLD=3
+          DISK_USAGE=${{ steps.check_disk.outputs.DISK_USAGE }}
+          TOTAL_DISK=${{ steps.check_disk.outputs.TOTAL_DISK }}
+
+          if [ "$DISK_USAGE" -gt "$THRESHOLD" ]; then
+            echo "::error title=Disk Usage Alert::ディスク使用量に注意してください（${DISK_USAGE}GB / ${TOTAL_DISK}GB）。"
+            exit 1
+          fi

--- a/.github/workflows/disk_space_alert.yml
+++ b/.github/workflows/disk_space_alert.yml
@@ -4,11 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 18 * * 1'
-  workflow_run:
-    workflows:
-      - Build Hugo site and upload to release
-    types:
-      - completed
 
 jobs:
   check-disk:

--- a/.github/workflows/disk_space_alert.yml
+++ b/.github/workflows/disk_space_alert.yml
@@ -1,6 +1,7 @@
 name: Disk Space Alert
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 18 * * 1'
   workflow_run:

--- a/.github/workflows/disk_space_alert.yml
+++ b/.github/workflows/disk_space_alert.yml
@@ -3,7 +3,7 @@ name: Disk Space Alert
 on:
   push:
     branches:
-      - main
+      - '*'
   workflow_dispatch:
   schedule:
     - cron: '0 18 * * 1'

--- a/.github/workflows/disk_space_alert.yml
+++ b/.github/workflows/disk_space_alert.yml
@@ -1,6 +1,9 @@
 name: Disk Space Alert
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
   schedule:
     - cron: '0 18 * * 1'


### PR DESCRIPTION
# What

#132 のディスク使用量の警告を出すワークフローを追加した．
実行のトリガーは週に 1 回またはビルドに設定した．
ステップサマリーで現在のディスク使用量を表示する．
3.0 GB 以上使用している場合には GitHub のワークフローコマンドで警告を出すようにし，ワークフローが失敗するようにした．
ワークフローが失敗すればメールが届くので Discord に通知するよりわかりやすいはず．

https://docs.github.com/ja/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions