### PR TITLE
GitHub の言語統計に Markdown を追加

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# Settings for Dev Container
 * text=auto eol=lf
 *.{cmd,[cC][mM][dD]} text eol=crlf
 *.{bat,[bB][aA][tT]} text eol=crlf
+
+# Settings for GitHub Linguist
+*.md linguist-detectable=true


### PR DESCRIPTION
GitHub の言語統計に Markdown が載っていたほうがリポジトリの実態を表していてわかりやすい気がした．
Markdown はプログラミング言語ではないので通常は言語統計に表示されないようになっているので，表示するための設定を `.gitattributes` に追加した．

Before
![image](https://github.com/user-attachments/assets/10d9695f-9b18-4904-94a1-2dbb98ef2bd2)

After
![image](https://github.com/user-attachments/assets/8d2c1239-1e4e-46f3-aa97-be5fdc37a6b1)
