### PR TITLE
Update hugo.yml

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -55,7 +55,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: "release-${{ github.sha }}-${{ github.run_id }}"
-          release_name: "nitmic-website ${{ env.CURRENT_DATETIME }}"
+          release_name: "${{ env.CURRENT_DATETIME }}"
           draft: false
           prerelease: false
 


### PR DESCRIPTION
Release 名が長いため見切れてしまうのが気になる．
nitmic-website の Release なので nitmic-website という Prefix は余分だと思う．

![image](https://github.com/user-attachments/assets/89658c1b-02ca-48be-9750-a7025d1b48f2)
