### PR TITLE
Feature/hugo module

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,11 @@
 {
-	"name": "Node.js",
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye",
+	"name": "Go",
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.23-bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/hugo:1": {
+			"version": "0.115.4"
+		}
+	},
 	"customizations": {
 		"vscode": {
 			"settings": {
@@ -20,11 +25,6 @@
 				"esbenp.prettier-vscode",
 				"tamasfe.even-better-toml"
 			]
-		}
-	},
-	"features": {
-		"ghcr.io/devcontainers/features/hugo:1": {
-			"version": "0.115.4"
 		}
 	}
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive
           fetch-depth: 0
       - name: Setup Pages
         id: pages

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "themes/mainroad"]
-	path = themes/mainroad
-	url = https://github.com/Vimux/Mainroad.git

--- a/README.md
+++ b/README.md
@@ -20,40 +20,36 @@ URL：http://nitmic.club.nitech.ac.jp/
 
 ### このリポジトリをローカルに clone する
 
-[Hugo](https://github.com/gohugoio/hugo) の [テーマ](https://themes.gohugo.io/) を使用する為、サブモジュールもクローンする必要があります
+下記のコマンドを実行することでこのリポジトリをローカルに clone することができます
 
 ```
-# クローン
-$ git clone git@github.com:nitmic/nitmic-hp.git
-
-# サブモジュールをクローン（更新）
-$ git submodule update --init --recursive
+$ git clone git@github.com:nitmic/nitmic-website.git
 ```
 
 ### ローカルでプレビューする
 
-静的サイトジェネレーター [Hugo](https://github.com/gohugoio/hugo) をインストールし、下記のコマンドを実行することでローカルでプレビューすることができます
+静的サイトジェネレーター [Hugo](https://github.com/gohugoio/hugo) と [GO](https://go.dev/) をインストールし、下記のコマンドを実行することでローカルでプレビューすることができます
 
 ```
 $ hugo server
-
-# ログの例
+Watching for changes in /workspaces/nitmic-website/{archetypes,assets,content,data,layouts,static}
+Watching for config changes in /workspaces/nitmic-website/config.toml
 Start building sites …
-hugo v0.89.4-AB01BA6E windows/amd64 BuildDate=2021-11-17T08:24:09Z VendorInfo=gohugoio
+hugo v0.115.4-dc9524521270f81d1c038ebbb200f0cfa3427cc5 linux/amd64 BuildDate=2023-07-20T06:49:57Z VendorInfo=gohugoio
+
+
                    | EN
 -------------------+------
-  Pages            | 115
-  Paginator pages  |   3
+  Pages            | 145
+  Paginator pages  |   5
   Non-page files   |   0
-  Static files     | 159
+  Static files     | 182
   Processed images |   0
-  Aliases          |  47
+  Aliases          |  60
   Sitemaps         |   1
   Cleaned          |   0
 
-Built in 362 ms
-Watching for changes in D:\repository\nitmic-hp\{archetypes,assets,content,data,layouts,static,themes}
-Watching for config changes in D:\repository\nitmic-hp\config.toml
+Built in 2611 ms
 Environment: "development"
 Serving pages from memory
 Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender

--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,6 @@ baseURL = 'https://nitmic.club.nitech.ac.jp/'
 title = "NITMic"     # NITMicに変更
 languageCode = "ja"  # ja に変更
 paginate = "10"      # Number of posts per page
-theme = "mainroad"
 disqusShortname = "" # Enable comments by entering your Disqus shortname
 googleAnalytics = "" # Enable Google Analytics by entering your tracking id
 
@@ -19,6 +18,10 @@ noTimes = true
 #日本語用の.Summary設定
 hasCJKLanguage = true
 summaryLength = 130
+
+[module]
+  [[module.imports]]
+    path = 'github.com/Vimux/Mainroad'
 
 [taxonomies]
 author = "authors"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/nitmic/nitmic-website
+
+go 1.23.4
+
+require github.com/Vimux/Mainroad v0.0.0-20240906135647-13e04b3694ea // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/Vimux/Mainroad v0.0.0-20240906135647-13e04b3694ea h1:OaHwcrJ9otV154RqEmGbVXNzvOlxdlVP/GDtkCXbhgk=
+github.com/Vimux/Mainroad v0.0.0-20240906135647-13e04b3694ea/go.mod h1:jLdMcAraEBvAuFdWPXNkLElbXEo4acKVaaL2kky8W+8=


### PR DESCRIPTION
# Why

- テーマを適用するために GitHub Submodules を用いているが，メンテナンスが煩雑になる要因の一つになっている

# What

- HUGO Modules に移行
  - https://gohugo.io/hugo-modules/
  - 前やったときは出来なかったけど今やったらできた 😢
- Dev Container を Go ベースに変更
- ドキュメントを修正
  - Submodules 関連の記述を除去
  - Go のインストールの記述を追加
  - 出力例を更新

close #73 