### PR TITLE
ポストのメタデータの軽微な修正

### DIFF
--- a/content/post/0001.md
+++ b/content/post/0001.md
@@ -1,5 +1,5 @@
 ---
-title: "サイトを更新しました2021"
+title: "サイトを更新しました 2021"
 description: "サイトを更新しました"
 thumbnail: "images/post/0001/image_0.png"
 date: "2021-04-08"

--- a/content/post/0008.md
+++ b/content/post/0008.md
@@ -1,5 +1,5 @@
 ---
-title: "NITMicのSoundcloudアカウントを作りました！"
+title: "NITMic の Soundcloud アカウントを作りました！"
 date: "2022-03-18"
 categories: ["記事"]
 thumbnail: "images/post/0008/image_0.png"

--- a/content/post/0008.md
+++ b/content/post/0008.md
@@ -1,5 +1,5 @@
 ---
-title: "NITMic の Soundcloud アカウントを作りました！"
+title: "NITMic の SoundCloud アカウントを作りました！"
 date: "2022-03-18"
 categories: ["記事"]
 thumbnail: "images/post/0008/image_0.png"

--- a/content/post/0010.md
+++ b/content/post/0010.md
@@ -3,7 +3,7 @@ title: "新歓ポスター 2022"
 description: "新入生大歓迎です。"
 date: "2022-04-07"
 thumbnail: "images/post/0010/kk.png"
-categories: ["記事"]
+categories: ["作品紹介"]
 tags: ["2022", "新歓", "デザイナー"]
 sidebar: "right"
 authors: ["tamaki", "たいち", "kk", "kuru", "ジュンセイ"]

--- a/content/post/0016.md
+++ b/content/post/0016.md
@@ -2,7 +2,7 @@
 title: "新歓ポスター 2024"
 date: "2024-04-06"
 thumbnail: "/images/post/0016/samune.png"
-categories: ["記事"]
+categories: ["作品紹介"]
 tags: ["2024", "新歓", "デザイナー"]
 authors: ["name", "fjktkm", "kk", "獺祭", "わたあめ", "ウナギ"]
 menu: "main"

--- a/content/post/0017.md
+++ b/content/post/0017.md
@@ -1,5 +1,5 @@
 ---
-title: "部誌 Archives 2023 発行"
+title: "部誌 Archives 2023"
 date: "2023-11-18"
 thumbnail: "images/post/0017/tweet-ad_1.png"
 categories: ["作品紹介"]

--- a/content/post/0017.md
+++ b/content/post/0017.md
@@ -2,7 +2,7 @@
 title: "部誌 Archives 2023 発行"
 date: "2023-11-18"
 thumbnail: "images/post/0017/tweet-ad_1.png"
-categories: ["記事"]
+categories: ["作品紹介"]
 description: "NITMic の部誌 Archives 2023 を発行しました！"
 tags: ["NITMic", "2023", "工大祭", "部誌"]
 authors: ["fjktkm"]

--- a/content/post/0018.md
+++ b/content/post/0018.md
@@ -2,7 +2,7 @@
 title: "NITMic 広報用ロールアップバナーを制作"
 date: "2024-11-16"
 thumbnail: "images/post/0018/IMG_4789.JPG"
-categories: ["記事"]
+categories: ["作品紹介"]
 description: "NITMic の広報用のロールアップバナーを制作しました！"
 tags: ["NITMic", "2024", "工大祭"]
 authors: ["fjktkm", "Oru", "kk"]

--- a/content/post/0018.md
+++ b/content/post/0018.md
@@ -1,5 +1,5 @@
 ---
-title: "NITMic 広報用ロールアップバナーを制作"
+title: "NITMic 広報用ロールアップバナー"
 date: "2024-11-16"
 thumbnail: "images/post/0018/IMG_4789.JPG"
 categories: ["作品紹介"]


### PR DESCRIPTION
# What

- 和文と欧文の間にスペースを追加
- SoundCloud のサービス名の全角半角が正確でなかったのを修正
- 記事扱いだったポストの一部を作品紹介に移行
- 「～を制作」のような冗長な表現を除去