### PR TITLE
ワイルドカードを使わないように修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,5 @@ jobs:
         run: |
           unzip "${{ steps.create_temp_dir.outputs.TEMP_DIR }}/hugo-site.zip" -d "${{ steps.create_temp_dir.outputs.TEMP_DIR }}/unzipped"
           rm -rf ../../../../public
-          mkdir -p ../../../../public
-          mv "${{ steps.create_temp_dir.outputs.TEMP_DIR }}/unzipped/public/"* ../../../../public/
+          mv "${{ steps.create_temp_dir.outputs.TEMP_DIR }}/unzipped/public/" ../../../../
           rm -rf "${{ steps.create_temp_dir.outputs.TEMP_DIR }}"


### PR DESCRIPTION
## 概要
- ワイルドカードでは隠しファイルは対象にならない[^1]らしい

## 対処
- ディレクトリごとにコピーするように修正
- mkdirする必要がなくなったのでその処理は削除

[^1]:[ワイルドカード指定 "*" ではドットファイルは対象にならない - THE BLUE NOWHERE](https://y-sumida.hatenablog.com/entry/20121001/1349078813)