### PR TITLE
Remove .flex class from custom.css

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1510,9 +1510,6 @@ textarea {
   padding-top: 1em;
 }
 
-.flex {
-  display: flex;
-}
 .flex-1 {
   flex-grow: 1;
 }


### PR DESCRIPTION

Removed .flex class definition from custom.css

## 概要
- 本家Mainroadテーマには存在しない .flex { display: flex; } が存在していた
  - .flex { display: flex; } が原因で #324 が発生していた
  - トップページの一部でもcssのズレが確認された
- よって .flex { display: flex; } を削除した

## 本家テーマには存在しない .flex { display: flex; } が存在している図
<img width="400" alt="image" src="https://github.com/user-attachments/assets/787c9a92-5935-494f-a8ef-375e7da3250c" />


## .flex { display: flex; } の有無で #324 が解決される図
| before | after |
| --- | --- |
| <img width="1915" height="986" alt="image" src="https://github.com/user-attachments/assets/1be1a19f-78b7-4b0d-8140-d1a3b7731acb" /> | <img width="1915" height="983" alt="image" src="https://github.com/user-attachments/assets/1f0d0d70-b00e-4ac4-8a5c-584c0d928c44" /> |
