### PR TITLE
fix: custom.css の古い記法とデッドコードを整理

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -25,27 +25,15 @@ section {
 	display: block;
 }
 
-:focus::-webkit-input-placeholder {
-	color: transparent;
-}
-
-:focus::-moz-placeholder {
-	color: transparent;
-}
-
-:focus:-moz-placeholder {
-	color: transparent;
-}
-
-:focus:-ms-input-placeholder {
+:focus::placeholder {
 	color: transparent;
 }
 
 /* Structure */
 html {
 	font-size: 100%;
-	-ms-text-size-adjust: none;
-	-webkit-text-size-adjust: none;
+	text-size-adjust: 100%;
+	-webkit-text-size-adjust: 100%;
 }
 
 body {
@@ -79,35 +67,23 @@ body {
 }
 
 .flex {
-	display: -webkit-flex;
 	display: flex;
 }
 
 .primary {
-	-webkit-flex: 1 0 65.83%;
 	flex: 1 0 65.83%;
-	-webkit-order: 1;
 	order: 1;
 	min-width: 0;
 }
 
-/*
-.card{
-	/* background-color: #000;
-}
-*/
-
 .sidebar {
-	-webkit-flex: 1 0 21.66%;		/* 初期値：31.6% */
 	flex: 1 0 21.66%;				/* 初期値：31.6% */
-	-webkit-order: 2;
 	order: 2;
 	min-width: 0;
 	margin: 0 0 0 2.5%;
 }
 
 .sidebar--left {
-	-webkit-order: 0;
 	order: 0;
 	margin: 0 2.5% 0 0;
 }
@@ -603,13 +579,10 @@ button:not(:-moz-focusring):focus > .menu__btn-title {
 	.menu__list,
 	.js .menu__list {
 		position: relative;
-		display: -webkit-flex;
 		display: flex;
-		-webkit-flex-wrap: wrap;
 		flex-wrap: wrap;
 		visibility: visible;
 		border: 0;
-		-webkit-transform: none;
 		transform: none;
 	}
 
@@ -984,7 +957,6 @@ button:not(:-moz-focusring):focus > .menu__btn-title {
 
 /* Pager (prev/next links) navigation */
 .pager {
-	-webkit-justify-content: space-between;
 	justify-content: space-between;
 	padding-top: 25px;
 	padding-bottom: 25px;
@@ -1008,7 +980,6 @@ button:not(:-moz-focusring):focus > .menu__btn-title {
 }
 
 .pager__item {
-	-webkit-flex: 1 1 50%;
 	flex: 1 1 50%;
 	max-width: 48%;
 }
@@ -1024,7 +995,6 @@ button:not(:-moz-focusring):focus > .menu__btn-title {
 
 /* Images / Video */
 img {
-	width: auto\9; /* ie8 */
 	max-width: 100%;
 	height: auto;
 	vertical-align: bottom;
@@ -1237,14 +1207,11 @@ textarea {
 }
 
 .footer__container {
-	-webkit-flex-flow: row wrap;
 	flex-flow: row wrap;
-	-webkit-justify-content: space-between;
 	justify-content: space-between;
 }
 
 .footer__links {
-	-webkit-order: 1;
 	order: 1;
 }
 
@@ -1405,17 +1372,8 @@ textarea {
 	  font-size: 18px;
 	  background: #f7f7f7;
 	  /* Center slide text vertically */
-	  display: -webkit-box;
-	  display: -ms-flexbox;
-	  display: -webkit-flex;
 	  display: flex;
-	  -webkit-box-pack: center;
-	  -ms-flex-pack: center;
-	  -webkit-justify-content: center;
 	  justify-content: center;
-	  -webkit-box-align: center;
-	  -ms-flex-align: center;
-	  -webkit-align-items: center;
 	  align-items: center;
 	}
 
@@ -1462,17 +1420,8 @@ textarea {
 
 
 
-/* カード一覧 */
-.cards {
-  /*display: flex;*/
-  /*flex-wrap: wrap;*/
-  /*align-items:flex-start;*/
-}
-
 /* カード */
 .card {
-  /*display: flex;*/
-  /* サムネイル, ドキュメント(名前、タグ、description, SNSアイコンなど)、を縦に並べる */
   flex-direction: column;
 
   flex: 0 0 30%;
@@ -1510,6 +1459,9 @@ textarea {
   padding-top: 1em;
 }
 
+.flex {
+  display: flex;
+}
 .flex-1 {
   flex-grow: 1;
 }

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1459,9 +1459,6 @@ textarea {
   padding-top: 1em;
 }
 
-.flex {
-  display: flex;
-}
 .flex-1 {
   flex-grow: 1;
 }


### PR DESCRIPTION
## 概要

Close #328

`assets/css/custom.css` に残っていた古いベンダープレフィックス、古い IE 向けハック、コメントアウト済みコードを整理します。

## 変更内容

- 不要なベンダープレフィックスを削除
- `text-size-adjust` を標準プロパティ / webkit 版ともに `100%` に整理
- 古い IE 向けハックとコメントアウト済みコードを削除

## 補足

PR #303 から CSS 整理だけを切り出した独立 PR です。
