### PR TITLE
fix: Google Fonts への依存を削除しユーザー既定フォントに委ねる

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,10 +1,5 @@
 {{- $highlightColor := .Site.Params.style.vars.highlightColor | default (.Site.Params.highlightColor | default "#e22d30") -}}
 
-{{- $fontSans := `"Open Sans", Helvetica, Arial, sans-serif` -}}
-{{- $fontMono := `SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace` -}}
-{{- $fontFamilyPrimary := .Site.Params.style.vars.fontFamilyPrimary | default $fontSans -}}
-{{- $fontFamilySecondary := .Site.Params.style.vars.fontFamilySecondary | default $fontMono -}}
-
 *,
 *::before,
 *::after {
@@ -38,7 +33,7 @@ html {
 
 body {
 	margin: 0;
-	font-family: {{ $fontFamilyPrimary }};
+	font-family: sans-serif;
 	font-size: 14px;
 	font-size: .875rem;
 	line-height: 1.6;
@@ -250,7 +245,7 @@ pre,
 code,
 kbd,
 samp {
-	font-family: {{ $fontFamilySecondary }};
+	font-family: monospace;
 	font-size: inherit;
 }
 
@@ -334,7 +329,7 @@ q {
 address {
 	margin-bottom: 20px;
 	margin-bottom: 1.25rem;
-	font-family: "Consolas", Courier New, Courier, monospace;
+	font-family: monospace;
 	line-height: 1.5;
 }
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -41,16 +41,6 @@
 	<script>(function(d,e){d[e]=d[e].replace("no-js","js");})(document.documentElement,"className");</script>
 	<meta name="description" content="{{ if .IsHome }}{{ .Site.Params.description }}{{ else }}{{ .Params.Description }}{{ end }}">
 
-
-	{{- $googleFontsLink := .Site.Params.googleFontsLink | default "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400&display=swap" }}
-	{{- if hasPrefix $googleFontsLink "https://fonts.googleapis.com/" }}
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-	<link rel="dns-prefetch" href="//fonts.googleapis.com">
-	<link rel="dns-prefetch" href="//fonts.gstatic.com">
-	<link rel="stylesheet" href="{{ $googleFontsLink }}">
-	{{- end }}
-
-
 	<!-- customCSSを適用している箇所 , rangeだから複数customCSS登録しても大丈夫そう？ -->
 	{{ $style := resources.Get "/css/custom.css" | resources.ExecuteAsTemplate "/css/custom.css" . | resources.Minify | resources.Fingerprint -}}
 	<link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous">


### PR DESCRIPTION
## Summary

- Google Fonts（Open Sans）の読み込みを削除し、レンダリングブロッキングを解消
- フォント指定をブラウザ・OSのデフォルトに委ねるよう変更
- Windows 11 のアップデートで Noto Sans JP がデフォルト搭載されたため、外部フォントの必要性が低下

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)