### PR TITLE
refactor: VSCode settings を .vscode/ に移行し extensions.json を新設

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,19 +8,6 @@
 	},
 	"customizations": {
 		"vscode": {
-			"settings": {
-				"files.autoSave": "afterDelay",
-				"editor.formatOnPaste": true,
-				"editor.formatOnSave": true,
-				"editor.formatOnType": true,
-				"files.trimFinalNewlines": true,
-				"files.trimTrailingWhitespace": true,
-				"files.insertFinalNewline": true,
-				"[markdown]": {
-					"editor.defaultFormatter": "esbenp.prettier-vscode",
-					"editor.formatOnSave": true
-				}
-			},
 			"extensions": [
 				"esbenp.prettier-vscode",
 				"tamasfe.even-better-toml"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+	"recommendations": [
+		"esbenp.prettier-vscode",
+		"tamasfe.even-better-toml"
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+	"files.autoSave": "afterDelay",
+	"editor.formatOnPaste": true,
+	"editor.formatOnSave": true,
+	"editor.formatOnType": true,
+	"files.trimFinalNewlines": true,
+	"files.trimTrailingWhitespace": true,
+	"files.insertFinalNewline": true,
+	"[markdown]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode",
+		"editor.formatOnSave": true
+	}
+}


### PR DESCRIPTION
## 変更の目的

`devcontainer.json` の `customizations.vscode` に書かれた設定は Dev Container 利用時にしか反映されない。Dev Container を使わずローカルで開発する場合にも同じエディタ設定・拡張機能推奨を適用できるよう、`.vscode/` 以下に移行する。

## Summary

- `devcontainer.json` の `customizations.vscode.settings` を `.vscode/settings.json` へ移行
- `extensions` は `devcontainer.json` に残存
- `.vscode/extensions.json` を新設（`recommendations` として同じ拡張機能を記載）

## Test plan

- [ ] Dev Container をリビルドして設定が正しく反映されることを確認
- [ ] VSCode で拡張機能の推奨が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)